### PR TITLE
Cast merchant id as integer

### DIFF
--- a/PMProGateway_checkout_finland.php
+++ b/PMProGateway_checkout_finland.php
@@ -315,7 +315,7 @@ class PMProGateway_checkout_finland extends PMProGateway
 	 */
 	static function getMerchant() {
 		return new Checkout\v1\Merchant(
-			pmpro_getOption('checkout_fi_merchant_id'),
+			intval(pmpro_getOption('checkout_fi_merchant_id')),
 			pmpro_getOption('checkout_fi_merchant_secret')
 		);
 	}


### PR DESCRIPTION
`Uncaught TypeError: Argument 1 passed to Checkout\v1\Merchant::__construct() must be of the type integer, string given`